### PR TITLE
Fixed web3j-cli  version for windows installer

### DIFF
--- a/installer.ps1
+++ b/installer.ps1
@@ -4,7 +4,7 @@ $PSDefaultParameterValues['*:ErrorAction']='Stop'
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 $ProgressPreference = 'SilentlyContinue'
 
-$web3j_version = $(Invoke-WebRequest -UseBasicParsing -Uri https://internal.services.web3labs.com/api/epirus/versions/latest).content
+$web3j_version = (Invoke-WebRequest -Uri "https://api.github.com/repos/web3j/web3j-cli/releases/latest").Content | ConvertFrom-Json | Select-Object -ExpandProperty tag_name | ForEach-Object { $_.Substring(1) }
 
 New-Item -Force -ItemType directory -Path "${env:USERPROFILE}\.web3j" | Out-Null
 $url = "https://github.com/web3j/web3j-cli/releases/download/v${web3j_version}/web3j-cli-shadow-${web3j_version}.zip"


### PR DESCRIPTION
### What does this PR do?
Fix for web3j-cli version for windows installer

### Where should the reviewer start?
installer.ps1 file

### Why is it needed?
Previous code was throwing old version, so updated it
